### PR TITLE
Add opentelemetry tracing

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -69,7 +69,8 @@ library
         transformers,
         unordered-containers >= 0.2.10.0,
         utf8-string,
-        hslogger
+        hslogger,
+        opentelemetry ==0.4.*
     if flag(ghc-lib)
       build-depends:
         ghc-lib >= 8.8,

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -111,6 +111,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
 import Data.Traversable
+import OpenTelemetry.Eventlog
 
 import Data.IORef
 import NameCache
@@ -867,12 +868,22 @@ usesWithStale key files = do
     values <- map (\(A value) -> value) <$> apply (map (Q . (key,)) files)
     zipWithM lastValue files values
 
+-- | Open an OpenTelemetry span around an action. Similar to opentelemetry's withSpan_, but specialized to Action
+withSpanAction_ :: Show k => k -> NormalizedFilePath -> Action a -> Action a
+withSpanAction_ key file action = actionBracket
+    ( do
+         span <- beginSpan (show key)
+         setTag span "File" (BS.pack $ fromNormalizedFilePath $ file)
+         return span
+    )
+    endSpan
+    (\_ -> action)
 
 defineEarlyCutoff
     :: IdeRule k v
     => (k -> NormalizedFilePath -> Action (Maybe BS.ByteString, IdeResult v))
     -> Rules ()
-defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> do
+defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> withSpanAction_ key file $ do
     extras@ShakeExtras{state, inProgress} <- getShakeExtras
     -- don't do progress for GetFileExists, as there are lots of non-nodes for just that one key
     (if show key == "GetFileExists" then id else withProgressVar inProgress file) $ do

--- a/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/src/Development/IDE/LSP/HoverDefinition.hs
@@ -24,6 +24,7 @@ import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 
 import qualified Data.Text as T
+import OpenTelemetry.Eventlog
 
 gotoDefinition :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError LocationResponseParams)
 hover          :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError (Maybe Hover))
@@ -57,7 +58,7 @@ request
   -> IdeState
   -> TextDocumentPositionParams
   -> IO (Either ResponseError b)
-request label getResults notFound found ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos _) = do
+request label getResults notFound found ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos _) = withSpan_ ("Request:" <> T.unpack label) $ do
     mbResult <- case uriToFilePath' uri of
         Just path -> logAndRunRequest label getResults ide pos path
         Nothing   -> pure Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,5 +16,6 @@ extra-deps:
 - tasty-rerun-1.1.17
 - ghc-check-0.5.0.1
 - extra-1.7.2
+- opentelemetry-0.4.2
 nix:
   packages: [zlib]

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -9,6 +9,7 @@ extra-deps:
 - lsp-test-0.11.0.2
 - ghc-check-0.5.0.1
 - hie-bios-0.5.0
+- opentelemetry-0.4.2
 
 # for ghc-8.10
 - Cabal-3.2.0.0

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -24,6 +24,7 @@ extra-deps:
 - heaps-0.3.6.1
 - ghc-check-0.5.0.1
 - extra-1.7.2
+- opentelemetry-0.4.2
 # For tasty-retun
 - ansi-terminal-0.10.3
 - ansi-wl-pprint-0.6.9

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -8,5 +8,6 @@ extra-deps:
 - ghc-check-0.5.0.1
 - hie-bios-0.5.0
 - extra-1.7.2
+- opentelemetry-0.4.2
 nix:
   packages: [zlib]


### PR DESCRIPTION
Adds tracing to shake actions (everything defined with
defineEarlyCutoff) and requests defined in HoverDefinition.hs.

It also adds opentelemetry to the dependencies